### PR TITLE
fix: update broken link for MonitoRSS website logo

### DIFF
--- a/src/client/src/js/components/ControlPanel/LeftMenu/index.js
+++ b/src/client/src/js/components/ControlPanel/LeftMenu/index.js
@@ -237,7 +237,7 @@ function LeftMenu (props) {
               ? (
                 <Header to='/'>
                   <div>
-                    <img alt='Discord RSS logo' src='https://discord.com/assets/d36b33903dafb0107bb067b55bdd9cbc.svg' width='30px' />
+                    <img alt='Discord RSS logo' src='/favicon.png' width='30px' />
                     <h3 style={{ margin: '0 10px' }}>MonitoRSS</h3>
                     <h4 style={{ margin: 0 }}>Control Panel</h4>
                   </div>


### PR DESCRIPTION
Right now, the link to the website logo seems to be for an image that was uploaded to Discord some time ago. However, that image is now inaccessible for some reason (error 403 - forbidden).

This updates the link for the website logo to the publicly accessible one that's already in the `public` folder.
For self-hosted instances, it will point to that instance's publicly accessible favicon image.